### PR TITLE
Vault 0.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.2.0 (2016-06-15)
+------------------
+
+* Breaking change to how the active node is determined from Consul. Prior to
+  this version, we looked for a 'vault' service with a health check named
+  'service:vault' (configurable via the VaultRedirector class constructor,
+  or the ``-c | --checkid`` command line argument) that was passing. With
+  Vault 0.6.0's automatic registration of service and health checks in Consul,
+  this needs to change. The logic to find the active node now looks for a node
+  in Consul that has the 'vault' service and a tag of 'active'.
+
 0.1.1 (2016-04-21)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -69,32 +69,15 @@ Requirements
 4. The `requests <https://pypi.python.org/pypi/requests>`_ package (will be installed automatically via ``pip``).
 5. If you wish to use TLS for incoming connections (highly recommended), the `pyOpenSSL <https://pypi.python.org/pypi/pyOpenSSL>`_ and `pem <https://pypi.python.org/pypi/pem>`_ packages. These can be automatically installed along with vault-redirector by using ``pip install vault-redirector[tls]``.
 6. `Consul <https://www.consul.io/>`_ running and configured with service checks for Vault (see below)
+7. Vault 0.6.0+
 
 Consul Service Checks
 ++++++++++++++++++++++
 
 In order to determine the active Vault instance, ``vault-redirector`` requires that Consul be running and monitoring the health of all Vault instances. Redirection can be to either the IP address or Consul node name running the active service.
 
-Here is example of the `Consul service definition <https://www.consul.io/docs/agent/services.html>`_ that we use (note we're running Vault with TLS); you can override the service name via command-line arguments:
-
-.. code-block:: json
-
-    {
-      "service":{
-        "name": "vault",
-        "tags": ["secrets"],
-        "port": 8200,
-        "check": {
-          "id": "api",
-          "name": "HTTPS API check on port 8200",
-          "http": "https://127.0.0.1:8200/v1/sys/health",
-          "interval": "5s",
-          "timeout" : "2s"
-        }
-      }
-    }
-
-**Please Note** that vault-redirector will use either the Consul node name or node address (IP) to redirect to; they should be set correctly to what clients will connect to.
+The current implementation in this package requires Vault 0.6.0+, which automatically
+registers its own service and health checks with Consul.
 
 Installation
 ------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -303,6 +303,7 @@ linkcheck_ignore = [
     r'https?://.*readthedocs\.org.*',
     r'https?://pypi\.python\.org/.*',
     r'https?://testpypi\.python\.org/.*',
+    r'https?://docs\.python\.org.*'
 ]
 
 # exclude module docstrings - see http://stackoverflow.com/a/18031024/211734

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -287,7 +287,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/': None,
+    'python': ('http://docs.python.org/2.7', None),
     'requests': ('http://docs.python-requests.org/en/master/', None),
     'twisted': ('https://twistedmatrix.com/documents/16.0.0/api/', None)
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,32 +72,15 @@ Requirements
 4. The `requests <https://pypi.python.org/pypi/requests>`_ package (will be installed automatically via ``pip``).
 5. If you wish to use TLS for incoming connections (highly recommended), the `pyOpenSSL <https://pypi.python.org/pypi/pyOpenSSL>`_ and `pem <https://pypi.python.org/pypi/pem>`_ packages. These can be automatically installed along with vault-redirector by using ``pip install vault-redirector[tls]``.
 6. `Consul <https://www.consul.io/>`_ running and configured with service checks for Vault (see below)
+7. Vault 0.6.0+
 
 Consul Service Checks
 ++++++++++++++++++++++
 
 In order to determine the active Vault instance, ``vault-redirector`` requires that Consul be running and monitoring the health of all Vault instances. Redirection can be to either the IP address or Consul node name running the active service.
 
-Here is example of the `Consul service definition <https://www.consul.io/docs/agent/services.html>`_ that we use (note we're running Vault with TLS); you can override the service name via command-line arguments:
-
-.. code-block:: json
-
-    {
-      "service":{
-        "name": "vault",
-        "tags": ["secrets"],
-        "port": 8200,
-        "check": {
-          "id": "api",
-          "name": "HTTPS API check on port 8200",
-          "http": "https://127.0.0.1:8200/v1/sys/health",
-          "interval": "5s",
-          "timeout" : "2s"
-        }
-      }
-    }
-
-**Please Note** that vault-redirector will use either the Consul node name or node address (IP) to redirect to; they should be set correctly to what clients will connect to.
+The current implementation in this package requires Vault 0.6.0+, which automatically
+registers its own service and health checks with Consul.
 
 Installation
 ------------
@@ -239,7 +222,8 @@ it will be a 503.
       "version": "0.1.0",
       "consul_host_port": "127.0.0.1:8500",
       "source": "https://github.com/manheim/vault-redirector-twisted",
-      "active_vault": "vault_hostname_or_ip:port"
+      "active_vault": "vault_hostname_or_ip:port",
+      "last_consul_poll": "YYYY-MM-DDTHH:MM:SS"
     }
 
 Logging and Debugging

--- a/vault_redirector/redirector.py
+++ b/vault_redirector/redirector.py
@@ -199,18 +199,15 @@ class VaultRedirector(object):
         r = requests.get(url)
         # return the current leader address
         for node in r.json():
-            for check in node['Checks']:
-                if check['CheckID'] != self.check_id:
-                    continue
-                if check['Status'] != 'passing':
-                    continue
-                port = node['Service']['Port']
-                n = "%s:%d" % (node['Node']['Node'], port)
-                if self.redir_ip:
-                    n = "%s:%d" % (node['Node']['Address'], port)
-                if self.log_enabled:
-                    logger.info("Got active node as: %s", n)
-                return n
+            if 'active' not in node['Service']['Tags']:
+                continue
+            port = node['Service']['Port']
+            n = "%s:%d" % (node['Node']['Node'], port)
+            if self.redir_ip:
+                n = "%s:%d" % (node['Node']['Address'], port)
+            if self.log_enabled:
+                logger.info("Got active node as: %s", n)
+            return n
         if self.log_enabled:
             logger.critical('NO vault services found with health check passing')
         return None

--- a/vault_redirector/tests/testdata.py
+++ b/vault_redirector/tests/testdata.py
@@ -80,7 +80,7 @@ test_get_active_node = [
             'ModifyIndex': 7,
             'Port': 8200,
             'Service': 'vault',
-            'Tags': ['secrets']
+            'Tags': ['secrets', 'standby']
         }
     },
     {
@@ -168,7 +168,7 @@ test_get_active_node = [
             'ModifyIndex': 21,
             'Port': 8200,
             'Service': 'vault',
-            'Tags': ['secrets']
+            'Tags': ['secrets', 'active']
         }
     },
     {
@@ -212,7 +212,7 @@ test_get_active_node = [
             'ModifyIndex': 16,
             'Port': 8200,
             'Service': 'vault',
-            'Tags': ['secrets']
+            'Tags': ['secrets', 'standby']
         }
     },
     {
@@ -256,7 +256,7 @@ test_get_active_node = [
             'ModifyIndex': 23,
             'Port': 8200,
             'Service': 'vault',
-            'Tags': ['secrets']
+            'Tags': ['secrets', 'standby']
         }
     }
 ]
@@ -264,3 +264,4 @@ test_get_active_node = [
 # same as above, but no passing vault check
 test_get_active_node_none = deepcopy(test_get_active_node)
 test_get_active_node_none[2]['Checks'][1]['Status'] = 'warning'
+test_get_active_node_none[2]['Service']['Tags'] = []

--- a/vault_redirector/version.py
+++ b/vault_redirector/version.py
@@ -36,5 +36,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
-_VERSION = '0.1.1'
+_VERSION = '0.2.0'
 _PROJECT_URL = 'https://github.com/manheim/vault-redirector-twisted'


### PR DESCRIPTION
Previously, we'd been recommending to manually set up the Vault service in Consul, and then configure and add a health check called 'service:vault' that this app would look at to determine the active Vault instance.

As of [vault 0.6.0](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#060-june-14th-2016), when Vault is run with the Consul HA Backend, it will automatically configure its own service and health checks in Consul. It identifies the active node by adding an ``active`` tag to the service on that node.

This change makes vault-redirector-twisted look for the ``active`` tag added by Vault >= 0.6.0 instead of looking for passing health checks.